### PR TITLE
WIP: Fix CI for faraday 2.14.1 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ ADD Gemfile /root
 ADD Gemfile.lock /root
 RUN \
     apk --update add --no-cache git openssh-client && \
+    apk --update add --no-cache --virtual .build-deps build-base && \
     cd /root && \
     bundle install && \
+    apk del .build-deps && \
     mkdir -p /repo && \
     mkdir -p ~/.ssh && chmod 700 ~/.ssh && \
     echo 'StrictHostKeyChecking no' >> ~/.ssh/config && chmod 600 ~/.ssh/config

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,24 +5,30 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     colorize (1.1.0)
     diff-lcs (1.5.0)
-    faraday (2.7.10)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     git-pr-release (2.2.0)
       colorize
       diff-lcs
       highline
       octokit
     highline (2.1.0)
+    json (2.18.1)
+    logger (1.7.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     octokit (7.0.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     public_suffix (5.0.3)
-    ruby2_keywords (0.0.5)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    uri (1.1.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
## Summary
- include the dependabot faraday update from #22
- fix Docker build failure by installing temporary build deps for native gem compilation
- remove build deps after `bundle install` to keep runtime image small

## Why
Existing PR #22 fails in CI because `json` native extension cannot compile without a C toolchain.

## Verification
- local: `docker build .` passes
- GitHub Actions: pending

## Related
- Supersedes: #22
