### PR TITLE
Update Docker image to Ruby 3.2.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.3-alpine3.15
+FROM ruby:3.2.11-alpine
 ADD Gemfile /root
 ADD Gemfile.lock /root
 RUN \


### PR DESCRIPTION
## Summary

- update the base Docker image from Ruby 3.1.3 to Ruby 3.2.11 so Bundler can install `public_suffix 7`, which is pulled in by `addressable 2.9.0`
- keep the change scoped to the base runtime so dependency update PRs can pass the existing `docker build .` check without additional lockfile edits

## Related

- unblocks https://github.com/kitsuyui/docker-git-pr-release/pull/26

## Testing

- `docker build .`
