### PR TITLE
Restrict docker build workflow token permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,6 +1,10 @@
 name: Test docker build
 on:
   - pull_request
+
+permissions:
+  contents: read
+
 jobs:
   buildx:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit read-only `GITHUB_TOKEN` permissions to the Docker build workflow.
- Keep the pull request build job limited to repository contents reads.

## Verification
- `git diff --check`
- `actionlint .github/workflows/docker-build.yml` reports existing old action-version diagnostics that also occur on `main` before this change.