### PR TITLE
Require explicit SSH host trust policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ RUN \
     cd /root && \
     bundle install && \
     apk del .build-deps && \
-    mkdir -p /repo && \
-    mkdir -p ~/.ssh && chmod 700 ~/.ssh && \
-    echo 'StrictHostKeyChecking no' >> ~/.ssh/config && chmod 600 ~/.ssh/config
+    mkdir -p /repo
 WORKDIR /repo
 ENTRYPOINT ["git-pr-release"]

--- a/README.md
+++ b/README.md
@@ -12,8 +12,20 @@ $ docker run -it \
   -e GIT_PR_RELEASE_BRANCH_PRODUCTION=production \
   -e GIT_PR_RELEASE_BRANCH_STAGING=master \
   -v $(pwd):/repo \
-  -v $HOME/.ssh:/root/.ssh kitsuyui/docker-git-pr-release
+  -v $HOME/.ssh:/root/.ssh:ro kitsuyui/docker-git-pr-release
 ```
+
+When you use SSH remotes, prepare `known_hosts` on the host before mounting
+the SSH directory. The image does not disable SSH host key checking by default.
+
+```console
+$ ssh-keyscan github.com >> $HOME/.ssh/known_hosts
+```
+
+Verify scanned host keys before trusting them.
+
+If an environment needs a different trust policy, pass it explicitly with
+`GIT_SSH_COMMAND`.
 
 ## Update Gemfile.lock
 


### PR DESCRIPTION
## Summary

- Stop writing `StrictHostKeyChecking no` into the image-level SSH config.
- Document that SSH users should mount a prepared `known_hosts` file and keep the mounted SSH directory read-only by default.
- Point custom SSH trust behavior to an explicit `GIT_SSH_COMMAND` override instead of changing the image default.

## Validation

- `git diff --check origin/main...HEAD`
- Started but not completed locally: `docker build .` stalled while loading base image metadata before project build steps ran, so it was canceled.
