### PR TITLE
Pin workflow action refs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
         # cf. https://github.com/marketplace/actions/docker-setup-buildx
 
       - name: Inspect builder

--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@51e37ab8ba42065f61ec02fb4819f0e89fd10cba # main


### PR DESCRIPTION
## Summary
- Pin `.github/workflows/docker-build.yml` action refs to full commit SHAs.
- Pin `.github/workflows/gitignore-in.yml` reusable workflow ref to the current upstream commit.
- Keep version comments next to the pinned refs for maintainability.

## Verification
- `actionlint .github/workflows/docker-build.yml .github/workflows/gitignore-in.yml`
- `git diff --check`
- Verified every workflow `uses:` ref is pinned to a 40-character SHA.
