### PR TITLE
Pin Alpine package versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM ruby:3.2.11-alpine
 ADD Gemfile /root
 ADD Gemfile.lock /root
 RUN \
-    apk --update add --no-cache git openssh-client && \
-    apk --update add --no-cache --virtual .build-deps build-base && \
+    apk --update add --no-cache git=2.52.0-r0 openssh-client-default=10.2_p1-r0 && \
+    apk --update add --no-cache --virtual .build-deps build-base=0.5-r3 && \
     cd /root && \
     bundle install && \
     apk del .build-deps && \


### PR DESCRIPTION
## Summary
- Pin direct Alpine package versions used by the Docker image.
- Replace the virtual OpenSSH client package name with the concrete package that Alpine resolves.
- Keep the Docker build dependency package version fixed as well.

## Test plan
- `docker build .`
