### PR TITLE
Remove -t TTY flag from CI usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ Docker distribution of [git-pr-release](https://github.com/motemen/git-pr-releas
 ## Usage
 
 ```console
-$ docker run -it \
+$ docker run \
   -e GIT_PR_RELEASE_TOKEN='xxxxxxxxxxx' \
   -e GIT_PR_RELEASE_BRANCH_PRODUCTION=production \
   -e GIT_PR_RELEASE_BRANCH_STAGING=master \
   -v $(pwd):/repo \
   -v $HOME/.ssh:/root/.ssh:ro kitsuyui/docker-git-pr-release
 ```
+
+For interactive debugging sessions, add `-it` flags to the command above.
+CI/CD environments typically do not allocate a TTY, so `-t` is omitted here.
 
 When you use SSH remotes, prepare `known_hosts` on the host before mounting
 the SSH directory. The image does not disable SSH host key checking by default.


### PR DESCRIPTION
## Summary

Remove the `-t` (pseudo-TTY allocation) flag from the CI usage example in README.

CI/CD environments (GitHub Actions and similar) do not allocate a TTY. Passing
`-t` in those contexts causes Docker to fail with:
`the input device is not a TTY`

The main usage example now omits `-it`. A note is added explaining that `-it`
can be used for interactive debugging sessions where a TTY is available.

## Test plan

- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm the example command works in a CI context without `-t`
