### PR TITLE
Make bundle install use frozen lockfile mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN \
     apk --update add --no-cache git=2.52.0-r0 openssh-client-default=10.2_p1-r0 && \
     apk --update add --no-cache --virtual .build-deps build-base=0.5-r3 && \
     cd /root && \
+    bundle config set --local frozen true && \
     bundle install && \
     apk del .build-deps && \
     mkdir -p /repo


### PR DESCRIPTION
## Summary
- configure Bundler's local frozen mode before installing gems in the Docker image build
- keep `bundle install` from silently updating or diverging from `Gemfile.lock`

## Validation
- `docker build .`
- `git diff --check`
