### PR TITLE
Document concurrency risk and recommend GitHub Actions concurrency group

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ Verify scanned host keys before trusting them.
 If an environment needs a different trust policy, pass it explicitly with
 `GIT_SSH_COMMAND`.
 
+## Concurrency
+
+`git-pr-release` checks for an existing release PR and creates one if none is
+found. This check-then-create sequence is not atomic: if two container runs
+overlap (e.g. two CI jobs triggered by rapid pushes to the staging branch),
+both may observe "no open PR" and each create a duplicate release PR.
+
+To prevent duplicate PRs, serialize runs at the CI level. With GitHub Actions,
+add a `concurrency` group to the workflow:
+
+```yaml
+concurrency:
+  group: git-pr-release-${{ github.ref }}
+  cancel-in-progress: false
+```
+
+Setting `cancel-in-progress: false` ensures that a queued run still executes
+after the current one finishes, so no release PR is skipped.
+
 ## Update Gemfile.lock
 
 ```console


### PR DESCRIPTION
## Summary

`git-pr-release` performs a check-then-create sequence that is not atomic.
When two CI jobs run concurrently (e.g. two rapid pushes to the staging
branch), both may observe "no open release PR" and each create a duplicate.
The README had no mention of this risk or how to prevent it.

This PR adds a **Concurrency** section that:

- Explains the race condition
- Recommends using a GitHub Actions `concurrency:` group to serialize runs
- Shows a concrete snippet with `cancel-in-progress: false` so queued runs
  still execute (no release PR is skipped)

## Changes

- `README.md`: added Concurrency section before Update Gemfile.lock

## Verification

README-only change; no build/test/lint commands defined.