### PR TITLE
Quote README shell path examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ When you use SSH remotes, prepare `known_hosts` on the host before mounting
 the SSH directory. The image does not disable SSH host key checking by default.
 
 ```console
-$ ssh-keyscan github.com >> $HOME/.ssh/known_hosts
+$ ssh-keyscan github.com >> "$HOME/.ssh/known_hosts"
 ```
 
 Verify scanned host keys before trusting them.
@@ -87,7 +87,7 @@ after the current one finishes, so no release PR is skipped.
 ## Update Gemfile.lock
 
 ```console
-$ docker run -v $(pwd):/root -it ruby sh -c 'cd /root; rm Gemfile; bundle lock'
+$ docker run -v "$(pwd):/root" -it ruby sh -c 'cd /root; rm Gemfile; bundle lock'
 ```
 
 ## LICENSE


### PR DESCRIPTION
## Summary

- Quote the `known_hosts` path in the SSH setup example.
- Quote the working-directory volume mount in the Gemfile.lock update example.
- Keep the documented commands behavior unchanged while preserving paths that contain spaces.

## Validation

- `git diff --check`
- Targeted README scan for the affected unquoted path patterns
- `docker build .`

## Notes

- This is a documentation-only change.
