### PR TITLE
Upgrade Ruby from 3.2.11 to 3.3.11 and add version constraint for git-pr-release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.11-alpine
+FROM ruby:3.3.11-alpine
 ADD Gemfile /root
 ADD Gemfile.lock /root
 RUN \

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem 'git-pr-release'
+gem 'git-pr-release', '~> 2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  git-pr-release
+  git-pr-release (~> 2)
 
 BUNDLED WITH
-   2.3.3
+   2.5.22


### PR DESCRIPTION
## Summary

- Upgrade base image from `ruby:3.2.11-alpine` to `ruby:3.3.11-alpine`
- Add pessimistic version constraint `~> 2` to `git-pr-release` in Gemfile
- Regenerate Gemfile.lock with Bundler 2.5.22

## Motivation

**Ruby upgrade:** Ruby 3.2.x enters security-only maintenance and reaches EOL in December 2026. Upgrading to Ruby 3.3.11 (actively supported) ahead of EOL avoids last-minute migration pressure and keeps the image on a supported runtime.

**Version constraint:** Adding `~> 2` to `gem 'git-pr-release'` guards against accidental major-version bumps that could introduce breaking changes silently on the next `bundle update`.

**Lockfile regeneration:** Bumping Bundler from 2.3.3 to 2.5.22 eliminates lockfile format drift between contributors using different Bundler versions.

## Changed Files

| File | Change |
|------|--------|
| `Dockerfile` | Base image: `ruby:3.2.11-alpine` → `ruby:3.3.11-alpine` |
| `Gemfile` | Added `~> 2` constraint to `git-pr-release` |
| `Gemfile.lock` | Regenerated with Bundler 2.5.22 |

## Compatibility Note

All three pinned Alpine packages (`git=2.52.0-r0`, `openssh-client-default=10.2_p1-r0`, `build-base=0.5-r3`) remain at the same versions and are available in the new Alpine 3.23 base image.
