### PR TITLE
Add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Report a problem with the Docker image
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of the problem.
+
+**Docker image version / tag**
+e.g. `kitsuyui/docker-git-pr-release:latest` or a specific digest.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. Run `docker run ...`
+2. See error
+
+**Expected behavior**
+A clear description of what you expected to happen.
+
+**Actual output**
+```
+Paste the relevant output here.
+```
+
+**Environment**
+- Host OS:
+- Docker version:
+- `git-pr-release` version (from `Gemfile.lock`):
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an improvement to the Docker image
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Problem or motivation**
+A clear and concise description of the problem this feature would solve.
+
+**Proposed solution**
+Describe what you would like to happen.
+
+**Alternatives considered**
+Describe any alternative solutions or features you have considered.
+
+**Additional context**
+Add any other context or screenshots here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- Describe what this PR changes and why. -->
+
+## Changes
+
+- 
+
+## Checklist
+
+- [ ] The Docker image builds successfully (`docker build -t docker-git-pr-release:local .`)
+- [ ] If gem versions changed, `Gemfile.lock` is updated
+- [ ] If the base image version changed, `Dockerfile` is updated accordingly

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainer via GitHub. All complaints will be reviewed and investigated.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+Thank you for considering contributing to docker-git-pr-release.
+
+## How to contribute
+
+1. Fork the repository and create a feature branch from `main`.
+2. Make your changes. If you are updating the base image or gem versions, also update `Gemfile.lock` (see below).
+3. Verify the Docker image builds successfully:
+   ```console
+   docker build -t docker-git-pr-release:local .
+   ```
+4. Open a pull request against `main` and fill out the PR template.
+
+## Updating Gemfile.lock
+
+Run the following command to regenerate the lockfile inside a matching Ruby image:
+
+```console
+docker run -v "$(pwd):/root" -it ruby sh -c 'cd /root; rm Gemfile.lock; bundle lock'
+```
+
+## Reporting issues
+
+Use the GitHub issue tracker. For security vulnerabilities, see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub issues.
+
+Instead, open a [GitHub Security Advisory](https://github.com/kitsuyui/docker-git-pr-release/security/advisories/new) or send an email to the maintainer. You can find contact information in the GitHub profile.
+
+We aim to acknowledge receipt within 5 business days and to provide a fix or mitigation plan within 30 days, depending on severity.
+
+## Scope
+
+This repository distributes a Docker image that bundles:
+
+- Ruby (base image version pinned in `Dockerfile`)
+- `git-pr-release` gem (version pinned in `Gemfile.lock`)
+- `git` and `openssh-client` (versions from the Alpine package index)
+
+Vulnerabilities in any of these components are in scope. Please include the component name and version in your report.


### PR DESCRIPTION
## Summary

Add missing community health files to improve the GitHub community health score and make contributing and security reporting easier.

## Changes

- `CONTRIBUTING.md`: documents how to contribute, including how to update `Gemfile.lock` inside a Ruby container
- `SECURITY.md`: security policy with a private vulnerability disclosure path via GitHub Security Advisories
- `CODE_OF_CONDUCT.md`: standard Contributor Covenant (adapted)
- `.github/ISSUE_TEMPLATE/bug_report.md`: structured bug report template
- `.github/ISSUE_TEMPLATE/feature_request.md`: feature request template
- `.github/PULL_REQUEST_TEMPLATE.md`: PR checklist covering build verification and lockfile updates

## Motivation

The repository had no community health files, leaving contributors without guidance on the PR process or security disclosure path. This adds the minimum set to address those gaps.

## Verification

All added files are Markdown only; no code or workflow logic was changed.