### PR TITLE
Document release process and restore Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM ruby:3.3.11-alpine
 ADD Gemfile /root
 ADD Gemfile.lock /root
 RUN \
-    apk --update add --no-cache git=2.52.0-r0 openssh-client-default=10.2_p1-r0 && \
-    apk --update add --no-cache --virtual .build-deps build-base=0.5-r3 && \
+    apk --update add --no-cache git=2.54.0-r0 openssh-client-default=10.3_p1-r0 && \
+    apk --update add --no-cache --virtual .build-deps build-base=0.5-r4 && \
     cd /root && \
     bundle config set --local frozen true && \
     bundle install && \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Docker distribution of [git-pr-release](https://github.com/motemen/git-pr-release)
 
+## Documentation
+
+- [Release process](docs/release.md)
+
 ## Usage
 
 Create a local env file for the variables passed to `git-pr-release`:

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,69 @@
+# Release process
+
+This repository distributes a Docker image for `git-pr-release`. Pull request
+CI verifies that the image builds and that the container can run
+`git-pr-release`, but this repository does not currently contain an automated
+Docker Hub publishing workflow. Treat the Git tag and GitHub Release as the
+source of truth for published image versions.
+
+## Version policy
+
+- Use tags in the `vMAJOR.MINOR.PATCH` format.
+- Publish the same version as the Docker image tag, for example
+  `kitsuyui/docker-git-pr-release:1.2.3`.
+- Move `latest` only when publishing a stable release that should be the
+  default image for new users.
+- If the pinned `git-pr-release` gem changes, mention the old and new gem
+  versions in the release notes.
+- If the Docker runtime contract changes, such as required environment
+  variables, mounted paths, or SSH behavior, call it out as a breaking change.
+
+## Release checklist
+
+1. Start from a clean `main` branch.
+2. Confirm the pinned gem version in `Gemfile.lock`.
+3. Build the image locally:
+
+   ```console
+   docker build --load -t docker-git-pr-release:ci .
+   ```
+
+4. Run the same runtime smoke test as CI:
+
+   ```console
+   docker run --rm --entrypoint sh docker-git-pr-release:ci \
+     -c "which git-pr-release && git --version"
+   ```
+
+5. Draft release notes with:
+   - the image tag,
+   - the pinned `git-pr-release` gem version,
+   - user-visible behavior changes,
+   - any migration or breaking-change notes.
+6. Create a `vMAJOR.MINOR.PATCH` Git tag and GitHub Release.
+7. Publish the Docker image with the matching version tag. Update `latest`
+   only for stable releases.
+8. Verify that the Docker Hub page shows the expected tag and that the image
+   can be pulled by tag.
+
+## Artifact contract
+
+The published image should:
+
+- run `git-pr-release` as its entrypoint,
+- keep `/repo` as the expected mounted working directory,
+- read runtime configuration from the upstream `git-pr-release` environment
+  variables and optional `.git-pr-release` file,
+- include the `git-pr-release` version pinned by `Gemfile.lock`.
+
+## Pre-releases
+
+For experimental changes, publish a GitHub pre-release and a versioned image
+tag only. Do not move `latest` for pre-releases.
+
+## Failed publish handling
+
+If publishing fails after a GitHub Release exists, leave the release visible
+only if the matching Docker image tag is available. Otherwise, mark the release
+as a draft or delete it, fix the publish problem, and recreate the release with
+notes that match the actually published artifact.


### PR DESCRIPTION
Summary
- Add a release process document that defines the version tag, image tag, release notes, pre-release, and failed-publish expectations.
- Link the release process from the README documentation list.
- Refresh Alpine package pins so the existing Docker build continues to resolve against the current base image package index.

Checks
- git diff --check
- typos README.md docs/release.md Dockerfile
- npx --yes markdownlint-cli2 README.md docs/release.md
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
- docker build --load -t docker-git-pr-release:ci .
- docker run --rm --entrypoint sh docker-git-pr-release:ci -c "which git-pr-release && git --version"
- docker run --rm --entrypoint sh docker-git-pr-release:ci -c "git-pr-release --help >/dev/null"
- collateral check: clean