### PR TITLE
Add versioned Docker Hub publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish Docker image
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: kitsuyui/docker-git-pr-release
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Why

No automated Docker Hub publishing workflow existed in this repository. The only CI workflow triggered on pull requests and only ran a build check — it had no push step. As a result, the publish path was opaque and the image on Docker Hub had no corresponding versioned tags in the repository.

## What changed

Added `.github/workflows/publish.yml` that:
- Triggers on `v[0-9]+.[0-9]+.[0-9]+` tag pushes (e.g. `v1.2.3`).
- Logs in to Docker Hub using `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets.
- Builds and pushes the image with version tags (`1.2.3`, `1.2`) and `latest`.

## Prerequisites

The following repository secrets must be set before this workflow can run:
- `DOCKERHUB_USERNAME`: Docker Hub account username
- `DOCKERHUB_TOKEN`: Docker Hub access token (read/write scope)

## Notes

- SHA pins for the Docker actions will be added by Renovate in a follow-up PR.
- Existing callers that pull `kitsuyui/docker-git-pr-release:latest` are unaffected.
- The workflow uses `docker/metadata-action` to derive tags from the pushed Git tag.
