### PR TITLE
Remove redundant apk --update from second apk add call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ADD Gemfile /root
 ADD Gemfile.lock /root
 RUN \
     apk --update add --no-cache git=2.52.0-r0 openssh-client-default=10.2_p1-r0 && \
-    apk --update add --no-cache --virtual .build-deps build-base=0.5-r3 && \
+    apk add --no-cache --virtual .build-deps build-base=0.5-r3 && \
     cd /root && \
     bundle config set --local frozen true && \
     bundle install && \


### PR DESCRIPTION
## Summary

Remove the `--update` flag from the second `apk add` call in the `RUN` instruction.

The `--update` flag is equivalent to `apk update` — it fetches the package index from the network. Within a single `RUN` instruction the index is already fresh after the first `apk --update add`, so repeating `--update` in the second call causes a redundant network round-trip and introduces a theoretical non-determinism window: if the Alpine repository is updated between the two fetches, the two calls may resolve different package versions.

## Changes

- `Dockerfile`: second `apk --update add` → `apk add` (index already current from first call)

## Verification

No automated test suite exists for this repo. The change is mechanical (removing one flag from an `apk add` invocation) and does not affect installed packages, the build-deps virtual group, or the runtime environment.
