### PR TITLE
Add entrypoint precondition checks

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,10 +25,20 @@ jobs:
           echo "Flags:     ${{ steps.buildx.outputs.flags }}"
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
 
+      - name: Test entrypoint wrapper
+        run: |
+          sh test/entrypoint.sh
+
       - name: Build
         run: |
           docker build --load -t docker-git-pr-release:ci .
 
       - name: Test image runtime
         run: |
-          docker run --rm --entrypoint sh docker-git-pr-release:ci -c "which git-pr-release && git --version"
+          docker run --rm --entrypoint sh docker-git-pr-release:ci -c "which git-pr-release && which git-pr-release-entrypoint && git --version"
+          set +e
+          output="$(docker run --rm docker-git-pr-release:ci 2>&1)"
+          status="$?"
+          set -e
+          test "$status" -eq 2
+          echo "$output" | grep "the current /repo directory must be a git working tree"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:3.3.11-alpine
 ADD Gemfile /root
 ADD Gemfile.lock /root
+COPY bin/git-pr-release-entrypoint /usr/local/bin/git-pr-release-entrypoint
 RUN \
     apk --update add --no-cache git=2.54.0-r0 openssh-client-default=10.3_p1-r0 && \
     apk --update add --no-cache --virtual .build-deps build-base=0.5-r4 && \
@@ -8,6 +9,7 @@ RUN \
     bundle config set --local frozen true && \
     bundle install && \
     apk del .build-deps && \
+    chmod +x /usr/local/bin/git-pr-release-entrypoint && \
     mkdir -p /repo
 WORKDIR /repo
-ENTRYPOINT ["git-pr-release"]
+ENTRYPOINT ["git-pr-release-entrypoint"]

--- a/bin/git-pr-release-entrypoint
+++ b/bin/git-pr-release-entrypoint
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+fail() {
+    printf 'docker-git-pr-release: %s\n' "$1" >&2
+    exit 2
+}
+
+append_missing() {
+    if [ -n "$missing_env" ]; then
+        missing_env="$missing_env $1"
+    else
+        missing_env="$1"
+    fi
+}
+
+require_env() {
+    name="$1"
+    eval "value=\${$name:-}"
+    if [ -z "$value" ]; then
+        append_missing "$name"
+    fi
+}
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    fail 'the current /repo directory must be a git working tree; mount your repository at /repo'
+fi
+
+missing_env=
+require_env GIT_PR_RELEASE_TOKEN
+
+if [ ! -f .git-pr-release ]; then
+    require_env GIT_PR_RELEASE_BRANCH_PRODUCTION
+    require_env GIT_PR_RELEASE_BRANCH_STAGING
+fi
+
+if [ -n "$missing_env" ]; then
+    fail "missing required environment variables: $missing_env"
+fi
+
+exec git-pr-release "$@"

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+ENTRYPOINT="$ROOT/bin/git-pr-release-entrypoint"
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/git-pr-release-entrypoint.XXXXXX")
+PATH_WITH_STUB="$WORKDIR/bin:$PATH"
+STUB_OUTPUT="$WORKDIR/stub-output"
+
+cleanup() {
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$WORKDIR/bin"
+cat >"$WORKDIR/bin/git-pr-release" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$*" >"$GIT_PR_RELEASE_STUB_OUTPUT"
+STUB
+chmod +x "$WORKDIR/bin/git-pr-release"
+
+assert_contains() {
+    case "$1" in
+        *"$2"*) ;;
+        *)
+            printf 'expected output to contain: %s\nactual output:\n%s\n' "$2" "$1" >&2
+            exit 1
+            ;;
+    esac
+}
+
+assert_fail_contains() {
+    dir="$1"
+    expected="$2"
+    shift 2
+
+    set +e
+    output=$(cd "$dir" && env -i PATH="$PATH_WITH_STUB" GIT_PR_RELEASE_STUB_OUTPUT="$STUB_OUTPUT" "$ENTRYPOINT" "$@" 2>&1)
+    status=$?
+    set -e
+
+    if [ "$status" -ne 2 ]; then
+        printf 'expected exit status 2, got %s\noutput:\n%s\n' "$status" "$output" >&2
+        exit 1
+    fi
+    assert_contains "$output" "$expected"
+}
+
+assert_success() {
+    dir="$1"
+    shift
+
+    : >"$STUB_OUTPUT"
+    (cd "$dir" && env -i \
+        PATH="$PATH_WITH_STUB" \
+        GIT_PR_RELEASE_STUB_OUTPUT="$STUB_OUTPUT" \
+        GIT_PR_RELEASE_TOKEN=token \
+        GIT_PR_RELEASE_BRANCH_PRODUCTION=production \
+        GIT_PR_RELEASE_BRANCH_STAGING=main \
+        "$ENTRYPOINT" "$@")
+
+    if [ "$(cat "$STUB_OUTPUT")" != "$*" ]; then
+        printf 'expected stub args "%s", got "%s"\n' "$*" "$(cat "$STUB_OUTPUT")" >&2
+        exit 1
+    fi
+}
+
+plain_dir="$WORKDIR/plain"
+missing_env_repo="$WORKDIR/missing-env"
+config_repo="$WORKDIR/config"
+success_repo="$WORKDIR/success"
+
+mkdir -p "$plain_dir" "$missing_env_repo" "$config_repo" "$success_repo"
+git -C "$missing_env_repo" init -q
+git -C "$config_repo" init -q
+git -C "$success_repo" init -q
+
+assert_fail_contains "$plain_dir" 'the current /repo directory must be a git working tree'
+assert_fail_contains "$missing_env_repo" 'missing required environment variables: GIT_PR_RELEASE_TOKEN GIT_PR_RELEASE_BRANCH_PRODUCTION GIT_PR_RELEASE_BRANCH_STAGING'
+
+touch "$config_repo/.git-pr-release"
+: >"$STUB_OUTPUT"
+(cd "$config_repo" && env -i \
+    PATH="$PATH_WITH_STUB" \
+    GIT_PR_RELEASE_STUB_OUTPUT="$STUB_OUTPUT" \
+    GIT_PR_RELEASE_TOKEN=token \
+    "$ENTRYPOINT" --dry-run)
+if [ "$(cat "$STUB_OUTPUT")" != "--dry-run" ]; then
+    printf 'expected .git-pr-release config path to call stub with --dry-run\n' >&2
+    exit 1
+fi
+
+assert_success "$success_repo" --dry-run


### PR DESCRIPTION
## Summary

- Add a small Docker entrypoint wrapper before `git-pr-release`.
- Report missing `/repo` git checkout and missing required environment variables with image-specific context.
- Add shell-level wrapper coverage and extend the Docker build workflow smoke test.

## Changes

- Add `bin/git-pr-release-entrypoint`.
- Switch the image `ENTRYPOINT` to the wrapper.
- Add `test/entrypoint.sh` for missing-precondition and pass-through behavior.
- Verify the wrapper in the pull request build workflow.

## Validation

- `sh -n bin/git-pr-release-entrypoint test/entrypoint.sh`
- `shellcheck bin/git-pr-release-entrypoint test/entrypoint.sh`
- `sh test/entrypoint.sh`
- `actionlint .github/workflows/docker-build.yml`
- `typos bin/git-pr-release-entrypoint test/entrypoint.sh Dockerfile .github/workflows/docker-build.yml`
- `git diff --check`
- `docker build --load -t docker-git-pr-release:ci .`
- `docker run --rm --entrypoint sh docker-git-pr-release:ci -c "which git-pr-release && which git-pr-release-entrypoint && git --version"`
- Default image run without a mounted git repository exits with status `2` and a clear `/repo` error.

## Notes

- Open Dockerfile maintenance PRs may need conflict resolution after this change merges.
