### PR TITLE
Cover entrypoint partial-missing-env and config-with-missing-token paths

### DIFF
--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -68,15 +68,38 @@ assert_success() {
 plain_dir="$WORKDIR/plain"
 missing_env_repo="$WORKDIR/missing-env"
 config_repo="$WORKDIR/config"
+config_token_missing_repo="$WORKDIR/config-token-missing"
+partial_missing_repo="$WORKDIR/partial-missing"
 success_repo="$WORKDIR/success"
 
-mkdir -p "$plain_dir" "$missing_env_repo" "$config_repo" "$success_repo"
+mkdir -p "$plain_dir" "$missing_env_repo" "$config_repo" "$config_token_missing_repo" "$partial_missing_repo" "$success_repo"
 git -C "$missing_env_repo" init -q
 git -C "$config_repo" init -q
+git -C "$config_token_missing_repo" init -q
+git -C "$partial_missing_repo" init -q
 git -C "$success_repo" init -q
 
 assert_fail_contains "$plain_dir" 'the current /repo directory must be a git working tree'
 assert_fail_contains "$missing_env_repo" 'missing required environment variables: GIT_PR_RELEASE_TOKEN GIT_PR_RELEASE_BRANCH_PRODUCTION GIT_PR_RELEASE_BRANCH_STAGING'
+
+touch "$config_token_missing_repo/.git-pr-release"
+assert_fail_contains "$config_token_missing_repo" 'missing required environment variables: GIT_PR_RELEASE_TOKEN'
+
+set +e
+partial_output=$(cd "$partial_missing_repo" && env -i \
+    PATH="$PATH_WITH_STUB" \
+    GIT_PR_RELEASE_STUB_OUTPUT="$STUB_OUTPUT" \
+    GIT_PR_RELEASE_TOKEN=token \
+    GIT_PR_RELEASE_BRANCH_PRODUCTION=production \
+    "$ENTRYPOINT" 2>&1)
+partial_status=$?
+set -e
+
+if [ "$partial_status" -ne 2 ]; then
+    printf 'expected exit status 2, got %s\noutput:\n%s\n' "$partial_status" "$partial_output" >&2
+    exit 1
+fi
+assert_contains "$partial_output" 'missing required environment variables: GIT_PR_RELEASE_BRANCH_STAGING'
 
 touch "$config_repo/.git-pr-release"
 : >"$STUB_OUTPUT"


### PR DESCRIPTION
## Why

The entrypoint's `require_env`/`append_missing` logic builds its error
message differently depending on which and how many variables are
absent, but `test/entrypoint.sh` only asserted the all-missing case (no
config, no env) and the all-present success case. Two failure paths
were untested:

- `.git-pr-release` present but `GIT_PR_RELEASE_TOKEN` missing
- exactly one branch variable (e.g. `GIT_PR_RELEASE_BRANCH_STAGING`)
  missing while the others are set

A refactor of the conditional order or the error-message concatenation
in those branches could regress the user-facing error message without
CI catching it.

## Change

Add two cases to `test/entrypoint.sh`:

- `config_token_missing_repo`: `.git-pr-release` present, no env vars
  set, asserts exit status 2 and the message names only
  `GIT_PR_RELEASE_TOKEN`.
- `partial_missing_repo`: no config, `GIT_PR_RELEASE_TOKEN` and
  `GIT_PR_RELEASE_BRANCH_PRODUCTION` set, `GIT_PR_RELEASE_BRANCH_STAGING`
  unset, asserts exit status 2 and the message names only the missing
  branch variable.

## Verification

- `sh test/entrypoint.sh` passes locally, including the two new cases.
- `shellcheck test/entrypoint.sh` reports no issues.
- No other files changed; `.github/workflows/docker-build.yml` already
  runs `test/entrypoint.sh` in CI, so no workflow change is needed.
